### PR TITLE
Fix Android preview initialization error 

### DIFF
--- a/src/android/BarcodeScanner.java
+++ b/src/android/BarcodeScanner.java
@@ -288,9 +288,9 @@ public class BarcodeScanner extends CordovaPlugin
     }
 
     private Camera.Size getOptimalPictureSize(Camera.Parameters params) {
-        Camera.Size bigEnough = params.getSupportedPictureSizes().get(0);
+        Camera.Size bigEnough = params.getSupportedPreviewSizes().get(0);
 
-        for (Camera.Size size : params.getSupportedPictureSizes()) {
+        for (Camera.Size size : params.getSupportedPreviewSizes()) {
             if (size.width >= mWidth && size.height >= mHeight
                 && size.width < bigEnough.width
                 && size.height < bigEnough.height


### PR DESCRIPTION
Fix for initialization error due to miss-match of SupportedPictureSizes and SupportedPreviewSizes.

On at least one device, the list of supported picture sizes and the list of supported preview sizes are wildly different. This leads to `getOptimalPictureSize` returning a resolution that is a supported _picture_ size, but not necessarily a supported _preview_ size.

The fix is simply to use the `getSupportedPreviewSizes` method to find candidates for resolution.
