### PR TITLE
Removing nonexistent Android permissions/features

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -307,13 +307,11 @@
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest">
-			<uses-permission android:name="android.permission.RECORD_VIDEO" />
 			<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 			<uses-permission android:name="android.permission.CAMERA" />
 
 			<uses-feature android:name="android.hardware.camera" />
 			<uses-feature android:name="android.hardware.camera.autofocus" />
-			<uses-feature android:name="android.hardware.camera.setParameters" />
     </config-file>
 
     <source-file src="src/android/BarcodeScanner.java" target-dir="src/com/sandyclock/plugins/BarcodeScanner" />


### PR DESCRIPTION
The feature `android.hardware.camera.setParameters` and the permission `android.permission.RECORD_VIDEO` are both non-existant. Because no device supports these, any app with these permissions in their `AndroidManifest.xml` will be incompatible with all Android devices. Removing these permissions let's the app be installed on devices.
